### PR TITLE
fixing slicing of multibyte strings (fixes #23 and #61)

### DIFF
--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -121,7 +121,7 @@ class Bid < ActiveRecord::Base
   def trigger_offered
     bid_note = Message.new()
     subject = "BID: " + self.estimated_hours.to_s + " hours - " + self.req.name 
-    bid_note.subject = subject.length > 75 ? subject.slice(0,75).concat("...") : subject
+    bid_note.subject = subject.mb_chars.length > 75 ? subject.mb_chars.slice(0,75).concat("...") : subject
     bid_note.content = ""
     bid_note.content << self.private_message_to_requestor + "\n--\n\n" if self.private_message_to_requestor.length > 0
     bid_note.content << "See your <a href=\"" + "http://" + server + req_path(self.req) + "\">request</a> to consider bid"
@@ -135,7 +135,7 @@ class Bid < ActiveRecord::Base
     save
     bid_note = Message.new()
     subject = "Bid accepted for " + self.req.name
-    bid_note.subject = subject.length > 75 ? subject.slice(0,75).concat("...") : subject
+    bid_note.subject = subject.mb_chars.length > 75 ? subject.mb_chars.slice(0,75).concat("...") : subject
     bid_note.content = "See the <a href=\"" + "http://" + server + req_path(self.req) + "\">request</a> to commit to bid"
     bid_note.sender = self.req.person
     bid_note.recipient = self.person
@@ -147,7 +147,7 @@ class Bid < ActiveRecord::Base
     save
     bid_note = Message.new()
     subject = "Bid committed for " + self.req.name
-    bid_note.subject = subject.length > 75 ? subject.slice(0,75).concat("...") : subject
+    bid_note.subject = subject.mb_chars.length > 75 ? subject.mb_chars.slice(0,75).concat("...") : subject
     bid_note.content = "Commitment made for your <a href=\"" + "http://" + server + req_path(self.req) + "\">request</a>. This is an automated message"
     bid_note.sender = self.person
     bid_note.recipient = self.req.person
@@ -159,7 +159,7 @@ class Bid < ActiveRecord::Base
     save
     bid_note = Message.new()
     subject = "Work completed for " + self.req.name
-    bid_note.subject = subject.length > 75 ? subject.slice(0,75).concat("...") : subject
+    bid_note.subject = subject.mb_chars.length > 75 ? subject.mb_chars.slice(0,75).concat("...") : subject
     bid_note.content = "Work completed for your <a href=\"" + "http://" + server + req_path(self.req) + "\">request</a>. Please approve transaction! This is an automated message"
     bid_note.sender = self.person
     bid_note.recipient = self.req.person

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -130,7 +130,7 @@ class Exchange < ActiveRecord::Base
   def send_payment_notification_to_worker
     exchange_note = Message.new()
     subject = I18n.translate('exchanges.notify.you_have_received_a_payment_of') + " " + self.amount.to_s + " " +  self.group.unit + " " + I18n.translate('for') + " " + self.metadata.name 
-    exchange_note.subject =  subject.length > 75 ? subject.slice(0,75).concat("...") : subject 
+    exchange_note.subject =  subject.mb_chars.length > 75 ? subject.mb_chars.slice(0,75).concat("...") : subject 
     exchange_note.content = self.customer.name + " " + I18n.translate('exchanges.notify.paid_you') + " " + self.amount.to_s + " " + self.group.unit + "."
     exchange_note.sender = self.customer
     exchange_note.recipient = self.worker
@@ -140,7 +140,7 @@ class Exchange < ActiveRecord::Base
   def send_suspend_payment_notification_to_worker
     exchange_note = Message.new()
     subject = I18n.translate('exchanges.notify.payment_suspended') + self.amount.to_s + " " + self.group.unit + " - " + I18n.translate('by') + " " + self.metadata.name
-    exchange_note.subject =  subject.length > 75 ? subject.slice(0,75).concat("...") : subject 
+    exchange_note.subject =  subject.mb_chars.length > 75 ? subject.mb_chars.slice(0,75).concat("...") : subject 
     exchange_note.content = self.customer.name + " " + I18n.translate('exchanges.notify.suspended_payment_of') + " " + self.amount.to_s + " " + self.group.unit + "."
     exchange_note.sender = self.customer
     exchange_note.recipient = self.worker


### PR DESCRIPTION
hi Tom,

This should fix the trouble we were having creating exchanges. the slice method was cutting multibyte UTF-8 characters in mid-character, resulting in invalid byte sequences.

an easy way to replicate from the ruby console is to slice a utf-8 string like "τεστ" an an odd number, e.g.

"τεστ".slice(0,3)

i fixed it using this: http://api.rubyonrails.org/classes/ActiveSupport/Multibyte/Chars.html
