### PR TITLE
allow setting credit limit back to nil

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,7 +63,7 @@ class Account < ActiveRecord::Base
 
   def check_credit_limit 
     if credit_limit_changed?
-      if credit_limit + balance < 0
+      if (not credit_limit.nil?) and (credit_limit + balance < 0)
         raise CanCan::AccessDenied.new("Denied: Updating credit limit for #{person.name} would put account in prohibited state.", :update, Account)
       end
     end


### PR DESCRIPTION
this fixes a 500 when trying to set our existing credit limit back to 'unlimited'.
