### PR TITLE
Polymorphic associations are easier.

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -28,7 +28,7 @@ class Comment < ActiveRecord::Base
   belongs_to :post
   belongs_to :event
 
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Comment'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
 
   validates_presence_of :body, :commenter
   validates_length_of :body, :maximum => MAX_TEXT_LENGTH

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -18,7 +18,7 @@ class Connection < ActiveRecord::Base
   
   belongs_to :person
   belongs_to :contact, :class_name => "Person", :foreign_key => "contact_id"
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Connection'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
   validates_presence_of :person_id, :contact_id
   
   # Status codes.

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,7 +27,7 @@ class Event < ActiveRecord::Base
   has_many :event_attendees
   has_many :attendees, :through => :event_attendees, :source => :person
   has_many :comments, :as => :commentable, :order => 'created_at DESC'
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Event'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
 
   validates_presence_of :title, :start_time, :person, :privacy
   validates_length_of :title, :maximum => MAX_TITLE_LENGTH

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -18,7 +18,7 @@ class Group < ActiveRecord::Base
   
   belongs_to :owner, :class_name => "Person", :foreign_key => "person_id"
   
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Group'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
 
   validates_uniqueness_of :name
   validates_uniqueness_of :unit, :allow_nil => true

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,7 +12,7 @@ class Membership < ActiveRecord::Base
   belongs_to :group
   belongs_to :person
   has_one :member_preference
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Membership'" #, :dependent => :destroy
+  has_many :activities, :as => :item #, :dependent => :destroy
 
   validates_presence_of :person_id, :group_id
   after_create :create_member_preference

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -37,7 +37,7 @@ class Photo < ActiveRecord::Base
                                   :icon         => '36>',
                                   :bounded_icon => '36x36>' }
   
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Photo'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
   validate :filename_to_upload_exists_and_images_are_correct_format
     
   after_save :log_activity

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,6 +16,6 @@
 
 class Post < ActiveRecord::Base
   include ActivityLogger
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Post'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
   attr_accessible nil
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -26,7 +26,7 @@ class Topic < ActiveRecord::Base
   has_many :posts, :order => 'created_at DESC', :dependent => :destroy,
                    :class_name => "ForumPost"
   has_many :viewers, :dependent => :destroy
-  has_many :activities, :foreign_key => "item_id", :conditions => "item_type = 'Topic'", :dependent => :destroy
+  has_many :activities, :as => :item, :dependent => :destroy
   validates_presence_of :name, :forum, :person
   validates_length_of :name, :maximum => MAX_NAME
   


### PR DESCRIPTION
Rails already provides a DSL for the reverse of a polymorphic association, using `has_many :activities, :as => :item` instead of a combination of `:foreign_key` and `:conditions` options.
