### PR TITLE
fix for Issue 283

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -23,7 +23,7 @@ class Address < ActiveRecord::Base
   belongs_to :person
   belongs_to :state
 
-  attr_accessible :address_line_1, :address_line_2, :address_line_3, :city, :state_id, :zipcode_plus_4
+  attr_accessible :address_line_1, :address_line_2, :address_line_3, :city, :state_id, :zipcode_plus_4, :address_privacy
 
   before_validation :geocode_address
   acts_as_mappable :lat_column_name => 'latitude', :lng_column_name => 'longitude'

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -331,7 +331,7 @@ class Person < ActiveRecord::Base
   end
 
   def address
-    addresses.first
+    addresses.where(:address_privacy => true).first
   end
 
   ## Account helpers

--- a/app/views/addresses/_form.html.erb
+++ b/app/views/addresses/_form.html.erb
@@ -1,4 +1,12 @@
 <div class="form_row">
+  <%= form.label t('addresses.form.share_address') %>
+   <% if @address.new_record? %>
+    <%= form.check_box :address_privacy, :checked => @current_person.org ? true : false %>
+   <% else %>
+    <%= form.check_box :address_privacy%>
+  <% end %>
+</div>
+<div class="form_row">
   <%= form.label t('addresses.form.address_line_1') %>
   <%= form.text_field :address_line_1 %>
 </div>

--- a/app/views/memberships/_membership_full.html.erb
+++ b/app/views/memberships/_membership_full.html.erb
@@ -80,7 +80,7 @@
           <span class="small"><%= t('people.edit.address') %></span>
           <span class="small"><%= h @person.address %></span>
       </div>
-    <%- end -%>
+    <% end %>
 
     <% if @person.web_site_url %>
       <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
       city: "City"
       state: "State"
       zipcode: "Zipcode"
+      share_address: "Share address:"
 
   bids:
     bid:

--- a/db/migrate/20130325164948_add_privacy_to_address.rb
+++ b/db/migrate/20130325164948_add_privacy_to_address.rb
@@ -1,0 +1,9 @@
+class AddPrivacyToAddress < ActiveRecord::Migration
+  def self.up
+    add_column :addresses, :address_privacy, :boolean, :default => false
+  end
+
+  def self.down
+    remove_column :addresses, :address_privacy
+  end
+end


### PR DESCRIPTION
Displayed address and website url in profile show page. 

Coming to phone number, its been already displayed in that page. But it will display only when the user makes it as 'visible to public' from his profile edit page. Let me know your comments on this. 
