### PR TITLE
#312: added sender link in message show

### DIFF
--- a/app/views/messages/_full_message.html.erb
+++ b/app/views/messages/_full_message.html.erb
@@ -8,7 +8,8 @@
   </div>
   <%= markdown(full_message.content) %>
   <p class="meta tools">
-    <%= t('messages.show.sent') %> <%= time_ago_in_words full_message.created_at %> <%= t('ago') %> |
+    <%= t('messages.show.sent') %> <%= t('by') %> <%= person_link full_message.sender %>
+     <%= time_ago_in_words full_message.created_at %> <%= t('ago') %> |
     <%= link_to t('messages.show.reply'), reply_message_path(full_message) %> |
     <% unless full_message.trashed?(current_person) -%>
       <%= link_to(t('messages.show.trash'), full_message, :method => :delete) %>


### PR DESCRIPTION
Relevant issue: 312

You should be able to proof that:
- Hover over the username in the top right
- Click Inbox
- Click Read
- Below message body you read "Send by <username> [...]"
  Please note that the <username> is a link which redirects you to sender's profile
