### PR TITLE
display deleted exchanges into admin section

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -148,7 +148,7 @@ class Ability
 
     can :read, Exchange
     can :destroy, Exchange do |exchange|
-      exchange.customer == person || person.admin?
+      (exchange.class != ExchangeDeleted) && (exchange.customer == person || person.admin?)
     end
     can :create, Exchange do |exchange|
       unless exchange.group

--- a/app/models/exchange_deleted.rb
+++ b/app/models/exchange_deleted.rb
@@ -1,0 +1,3 @@
+class ExchangeDeleted < Exchange
+
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -39,7 +39,7 @@ end
     export
   end
 
-  config.included_models = [Account,Address,State,AccountDeactivated,Preference,Exchange,ForumPost,FeedPost,BroadcastEmail,Person,PersonDeactivated,Category,Neighborhood,Req,Offer,BusinessType,ActivityStatus,PlanType]
+  config.included_models = [Account,Address,State,AccountDeactivated,Preference,Exchange,ForumPost,FeedPost,BroadcastEmail,Person,PersonDeactivated,Category,Neighborhood,Req,Offer,BusinessType,ActivityStatus,PlanType, ExchangeDeleted]
 
   config.model State do
     visible false
@@ -314,6 +314,27 @@ end
       end
       field :notes, :text
       #field :metadata
+    end
+  end
+
+  config.model ExchangeDeleted do
+    label do
+      'Deleted exchange'
+    end
+    list do
+      scope do
+        only_deleted
+      end
+      field :created_at
+      field :customer
+      field :worker
+      field :amount
+      field :notes do
+        label "Memo"
+        formatted_value do
+          bindings[:object].memo
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In the admin view,  I have added a 'deleted exchange' link just below the 'exchanges' link. when admin click on "deleted exchange" link, deleted exchanges would be displayed.
