### PR TITLE
what about removing the silent-postgres gem?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ group :development, :test do
   gem 'debugger'
   gem "heroku-api"
   gem 'sqlite3'
-  gem "silent-postgres"
   gem "rack"
   gem "rack-test"
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,7 +335,6 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    silent-postgres (0.1.1)
     simple-rss (1.2.3)
     simple_oauth (0.1.9)
     slop (3.3.3)
@@ -445,7 +444,6 @@ DEPENDENCIES
   rspec-rails
   ruby-openid
   sass-rails
-  silent-postgres
   spork
   sqlite3
   texticle


### PR DESCRIPTION
When running the test, there is too much waring about the silence method of Logger which has been removed in rails 4.

```
DEPRECATION WARNING: silence is deprecated and will be removed from Rails 4.0. (called from pk_and_sequence_for_with_silencer at (eval):2)
```

So I think we can remove the silent-postgres gem if it is not so useful.
https://github.com/dolzenko/silent-postgres/issues/19
